### PR TITLE
bug: getAddress returning undefined

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -2,6 +2,7 @@ import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
 import * as dotenv from "dotenv";
 import { getHardhatConfigNetworks } from "@zetachain/addresses-tools/dist/networks";
+import { getAddress } from "@zetachain/addresses";
 
 import "./tasks/account";
 import "./tasks/faucet";
@@ -11,6 +12,14 @@ import "./tasks/verify";
 dotenv.config();
 const PRIVATE_KEYS =
   process.env.PRIVATE_KEY !== undefined ? [`0x${process.env.PRIVATE_KEY}`] : [];
+
+console.log(
+  getAddress({
+    address: "zetaTokenConsumerUniV3",
+    networkName: "polygon-mumbai",
+    zetaNetwork: "athens",
+  })
+);
 
 const config: HardhatUserConfig = {
   solidity: "0.8.18",


### PR DESCRIPTION
```
  getAddress({
    address: "zetaTokenConsumerUniV3",
    networkName: "polygon-mumbai",
    zetaNetwork: "athens",
  })
```

Returns `undefined` even though Polygon has [zetaTokenConsumerUniV3 defined](https://github.com/zeta-chain/zetachain/blob/47d5bcf1d5657c55ce922ff74df10b26af936589/packages/addresses/src/addresses.athens.json#L75).

To reproduce just run `npx hardhat`.

cc @andresaiello 