### PR TITLE
ci: add workflow to record visits/clones

### DIFF
--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -1,0 +1,17 @@
+name: github-repo-stats
+
+on:
+  schedule:
+    - cron: "0 23 * * *"
+  workflow_dispatch:
+
+jobs:
+  j1:
+    name: github-repo-stats
+    if: github.repository == 'zeta-chain/template'
+    runs-on: ubuntu-latest
+    steps:
+      - name: run-ghrs
+        uses: jgehrcke/github-repo-stats@RELEASE
+        with:
+          ghtoken: ${{ secrets.ghrs_github_api_token }}


### PR DESCRIPTION
Collects info publicly available in the [Insights](https://github.com/zeta-chain/template/pulse) tab to overcome the 14 day limitation of GitHub's built-in traffic statistics.

Stats will be available in a separate branch: [`github-repo-stats`](https://github.com/zeta-chain/template/tree/github-repo-stats).