### PR TITLE
fix: remove foundry import

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,5 +1,4 @@
 import "@nomicfoundation/hardhat-toolbox";
-import "@nomicfoundation/hardhat-foundry";
 import "@zetachain/toolkit/tasks";
 
 import { getHardhatConfigNetworks } from "@zetachain/networks";


### PR DESCRIPTION
This import was added for convenience for Forge users, but apparently having this import requires you to have Forge CLI installed. If you don't have it, it throws an error.